### PR TITLE
added external (hardware) trigger support, from latest camera1394

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,8 @@ set(DRIVER_SOURCES
   src/nodes/dev_camera1394stereo.cpp
   src/nodes/featuresstereo.cpp
   src/nodes/format7stereo.cpp
-  src/nodes/modes.cpp)
+  src/nodes/modes.cpp
+  src/nodes/trigger.cpp)
 
 # Mac OSX requires extra linker parameters
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")

--- a/cfg/Camera1394Stereo.cfg
+++ b/cfg/Camera1394Stereo.cfg
@@ -251,6 +251,53 @@ gen.add("sharpness", double_t, SensorLevels.RECONFIGURE_RUNNING,
 gen.add("auto_shutter", int_t, SensorLevels.RECONFIGURE_RUNNING,
         "Shutter control state.", 1, 0, 4, edit_method = controls)
 
+gen.add("external_trigger", bool_t, SensorLevels.RECONFIGURE_RUNNING,
+        "External trigger power state", False)
+
+gen.add("software_trigger", bool_t, SensorLevels.RECONFIGURE_RUNNING,
+        "Software trigger power state", False)
+
+trigger_modes = gen.enum([gen.const("Mode_0", str_t, "mode_0", "Exposure starts with a falling edge and stops when the the exposure specified by the SHUTTER feature is elapsed"),
+                    gen.const("Mode_1", str_t, "mode_1", "Exposure starts with a falling edge and stops with the next rising edge"),
+                    gen.const("Mode_2", str_t, "mode_2", "The camera starts the exposure at the first falling edge and stops the integration at the nth falling edge"),
+                    gen.const("Mode_3", str_t, "mode_3", "This is an internal trigger mode. The trigger is generated every n*(period of fastest framerate)"),
+                    gen.const("Mode_4", str_t, "mode_4", "A multiple exposure mode. N exposures are performed each time a falling edge is observed on the trigger signal. Each exposure is as long as defined by the SHUTTER feature"),
+                    gen.const("Mode_5", str_t, "mode_5", "Same as Mode 4 except that the exposure is is defined by the length of the trigger pulse instead of the SHUTTER feature"),
+                    gen.const("Mode_14", str_t, "mode_14", "-- vendor specified trigger mode"),
+                    gen.const("Mode_15", str_t, "mode_15", "-- vendor specified trigger mode")],
+                    "Trigger modes")
+
+gen.add("trigger_mode", str_t, SensorLevels.RECONFIGURE_RUNNING,
+        "External trigger mode", "mode_0",
+       edit_method = trigger_modes)
+
+trigger_sources = \
+       gen.enum([gen.const("Source_0", str_t, "source_0", ""),
+                  gen.const("Source_1", str_t, "source_1", ""),
+                  gen.const("Source_2", str_t, "source_2", ""),
+                  gen.const("Source_3", str_t, "source_3", ""),
+                  gen.const("Source_Software", str_t, "source_software", "")],
+                  "External trigger sources")
+
+gen.add("trigger_source", str_t, SensorLevels.RECONFIGURE_RUNNING,
+        "External trigger source", "source_0",
+        edit_method = trigger_sources)
+
+trigger_polarity = \
+        gen.enum([gen.const("Active_Low", str_t, "active_low", ""),
+                  gen.const("Active_High", str_t, "active_high", "")],
+                  "Trigger polarity")
+
+gen.add("trigger_polarity", str_t, SensorLevels.RECONFIGURE_RUNNING,
+        "Trigger polarity", "active_low",
+        edit_method = trigger_polarity)
+
+gen.add("auto_trigger", int_t, SensorLevels.RECONFIGURE_RUNNING,
+        "Trigger control state.", 1, 0, 4, edit_method = controls)
+
+gen.add("trigger", double_t, SensorLevels.RECONFIGURE_RUNNING,
+        "Trigger parameter N", 0., 0., 4095.)
+
 gen.add("shutter", double_t, SensorLevels.RECONFIGURE_RUNNING,
         "Shutter speed.", 1., 0., 4095.)
 gen.add("auto_pan", int_t, SensorLevels.RECONFIGURE_RUNNING,

--- a/src/nodes/dev_camera1394stereo.h
+++ b/src/nodes/dev_camera1394stereo.h
@@ -74,7 +74,7 @@ namespace camera1394stereo
 
     int open(camera1394stereo::Camera1394StereoConfig &newconfig);
     int close();
-    void readData (sensor_msgs::Image &image, sensor_msgs::Image &image2);
+    bool readData (sensor_msgs::Image &image, sensor_msgs::Image &image2);
 
     /** check whether CameraInfo matches current video mode
      *

--- a/src/nodes/driver1394stereo.cpp
+++ b/src/nodes/driver1394stereo.cpp
@@ -287,7 +287,7 @@ namespace camera1394stereo_driver
       {
         // Read data from the Camera
         ROS_DEBUG_STREAM("[" << camera_name_ << "] reading data");
-        dev_->readData(*(image[LEFT]), *(image[RIGHT]));
+        success = dev_->readData(*(image[LEFT]), *(image[RIGHT]));
         ROS_DEBUG_STREAM("[" << camera_name_ << "] read returned");
       }
     catch (camera1394stereo::Exception& e)

--- a/src/nodes/featuresstereo.h
+++ b/src/nodes/featuresstereo.h
@@ -39,7 +39,7 @@
 #define _FEATURES_H_
 
 #include <dc1394/dc1394.h>
-
+#include "trigger.h"
 #include "camera1394stereo/Camera1394StereoConfig.h"
 typedef camera1394stereo::Camera1394StereoConfig Config;
 
@@ -65,6 +65,11 @@ public:
   ~Features() {};
   bool initialize(Config *newconfig);
   void reconfigure(Config *newconfig);
+
+  inline bool isTriggerPowered()
+  {
+         return trigger_->isPowered();
+  }
 
 private:
   typedef int state_t;      ///< camera1394::Camera1394_* state values
@@ -92,6 +97,20 @@ private:
       }
     return false;
   }
+
+  /** Does this camera support triggering?
+  *
+  * @pre feature_set_ initialized for this camera
+  * @return true if triggering supported
+  */
+  inline bool hasTrigger(void)
+  {
+    return DC1394_TRUE == feature_set_.feature[DC1394_FEATURE_TRIGGER
+                                               - DC1394_FEATURE_MIN].available;
+  }
+
+  // pointer to subordinate trigger class
+  boost::shared_ptr<Trigger> trigger_;
 
   bool setMode(dc1394feature_info_t *finfo, dc1394feature_mode_t mode);
   void setOff(dc1394feature_info_t *finfo);

--- a/src/nodes/trigger.cpp
+++ b/src/nodes/trigger.cpp
@@ -1,0 +1,524 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013 Boris Gromov, BioRobotics Lab at Korea Tech
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the author nor other contributors may be
+ *     used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <ros/ros.h>
+#include "trigger.h"
+
+/** @file
+
+ @brief libdc1394 triggering modes interfaces
+
+ @author Boris Gromov
+ */
+
+// initializing constants
+const std::string Trigger::trigger_mode_names_[DC1394_TRIGGER_MODE_NUM] = {"mode_0", "mode_1", "mode_2", "mode_3", "mode_4",
+                                                                         "mode_5", "mode_14", "mode_15", };
+const std::string Trigger::trigger_source_names_[DC1394_TRIGGER_SOURCE_NUM] = {"source_0", "source_1", "source_2",
+                                                                             "source_3", "source_software", };
+const std::string Trigger::trigger_polarity_names_[DC1394_TRIGGER_ACTIVE_NUM] = {"active_low", "active_high", };
+
+bool Trigger::findTriggerMode(std::string str)
+{
+  if (str == "mode_0")
+    triggerMode_ = DC1394_TRIGGER_MODE_0;
+  else if(str == "mode_1")
+    triggerMode_ = DC1394_TRIGGER_MODE_1;
+  else if(str == "mode_2")
+    triggerMode_ = DC1394_TRIGGER_MODE_2;
+  else if(str == "mode_3")
+    triggerMode_ = DC1394_TRIGGER_MODE_3;
+  else if(str == "mode_4")
+    triggerMode_ = DC1394_TRIGGER_MODE_4;
+  else if(str == "mode_5")
+    triggerMode_ = DC1394_TRIGGER_MODE_5;
+  else if(str == "mode_14")
+    triggerMode_ = DC1394_TRIGGER_MODE_14;
+  else if(str == "mode_15")
+    triggerMode_ = DC1394_TRIGGER_MODE_15;
+  else
+  {
+    triggerMode_ = (dc1394trigger_mode_t) DC1394_TRIGGER_MODE_NUM;
+    return false;
+  }
+
+  return true;
+}
+
+bool Trigger::findTriggerSource(std::string str)
+{
+  if (str == "source_0")
+    triggerSource_ = DC1394_TRIGGER_SOURCE_0;
+  else if(str == "source_1")
+    triggerSource_ = DC1394_TRIGGER_SOURCE_1;
+  else if(str == "source_2")
+    triggerSource_ = DC1394_TRIGGER_SOURCE_2;
+  else if(str == "source_3")
+    triggerSource_ = DC1394_TRIGGER_SOURCE_3;
+  else if(str == "source_software")
+    triggerSource_ = DC1394_TRIGGER_SOURCE_SOFTWARE;
+  else
+  {
+    triggerSource_ = (dc1394trigger_source_t) DC1394_TRIGGER_SOURCE_NUM;
+    return false;
+  }
+
+  return true;
+}
+
+bool Trigger::findTriggerPolarity(std::string str)
+{
+  if(str == "active_low")
+    triggerPolarity_ = DC1394_TRIGGER_ACTIVE_LOW;
+  else if(str == "active_high")
+    triggerPolarity_ = DC1394_TRIGGER_ACTIVE_HIGH;
+  else
+  {
+    triggerPolarity_ = (dc1394trigger_polarity_t) DC1394_TRIGGER_ACTIVE_NUM;
+    return false;
+  }
+
+  return true;
+}
+
+bool Trigger::checkTriggerSource(dc1394trigger_source_t source)
+{
+  for(size_t i = 0; i < triggerSources_.num; i++)
+    if(source == triggerSources_.sources[i]) return true;
+
+  return false;
+}
+
+/** Get supported external trigger sources.
+ *
+ *  @param camera points to DC1394 camera struct
+ *  @return true if successful
+ */
+bool Trigger::enumSources(dc1394camera_t *camera, dc1394trigger_sources_t &sources)
+{
+  dc1394error_t err = dc1394_external_trigger_get_supported_sources(camera, &sources);
+  if (err != DC1394_SUCCESS)
+  {
+    ROS_FATAL("enumTriggerSources() failed: %d", err);
+    return false; // failure
+  }
+
+    std::ostringstream ss;
+    if(sources.num != 0)
+    {
+      for(size_t i = 0; i < sources.num - 1; i++)
+        ss << triggerSourceName(sources.sources[i]) << ", ";
+      ss << triggerSourceName(sources.sources[sources.num - 1]);
+    }
+    else
+    {
+      ss << "none";
+    }
+
+    ROS_DEBUG_STREAM("Trigger sources: " << ss.str());
+  return true;
+}
+
+/** Get external trigger polarity.
+ *
+ *  @param camera points to DC1394 camera struct.
+ *  @return corresponding dc1394trigger_polarity_t enum value selected,
+ *                 if successful; DC1394_TRIGGER_ACTIVE_NUM if not.
+ */
+dc1394trigger_polarity_t Trigger::getPolarity(dc1394camera_t *camera)
+{
+  dc1394trigger_polarity_t current_polarity;
+
+  dc1394bool_t has_polarity;
+  dc1394error_t err = dc1394_external_trigger_has_polarity(camera, &has_polarity);
+  if (err != DC1394_SUCCESS)
+  {
+    ROS_FATAL("getPolarity() failed: %d", err);
+    return (dc1394trigger_polarity_t) DC1394_TRIGGER_ACTIVE_NUM; // failure
+  }
+
+  if (has_polarity == DC1394_TRUE)
+  {
+    err = dc1394_external_trigger_get_polarity(camera, &current_polarity);
+    if (err != DC1394_SUCCESS)
+    {
+      ROS_FATAL("getPolarity() failed: %d", err);
+      return (dc1394trigger_polarity_t) DC1394_TRIGGER_ACTIVE_NUM; // failure
+    }
+  }
+  else
+  {
+    ROS_ERROR("Polarity is not supported");
+    return (dc1394trigger_polarity_t) DC1394_TRIGGER_ACTIVE_NUM; // failure
+  }
+
+  return current_polarity; // success
+}
+
+/** Set external trigger polarity.
+ *  @param camera points to DC1394 camera struct
+ *  @param[in,out] polarity Config parameter for this option,
+ *                 updated if the camera does not support the
+ *                 requested value
+ *  @return true if polarity set successfully, false if not.
+ */
+bool Trigger::setPolarity(dc1394camera_t *camera, dc1394trigger_polarity_t &polarity)
+{
+  dc1394trigger_polarity_t current_polarity = getPolarity(camera);
+
+  dc1394bool_t has_polarity;
+  dc1394error_t err = dc1394_external_trigger_has_polarity(camera, &has_polarity);
+  if (err != DC1394_SUCCESS)
+  {
+    ROS_FATAL("setPolarity() failed: %d", err);
+    return false; // failure
+  }
+
+  if (has_polarity == DC1394_TRUE)
+  {
+    // if config not changed, then do nothing
+    if(current_polarity == polarity) return true;
+
+    err = dc1394_external_trigger_set_polarity(camera, polarity);
+    if (err != DC1394_SUCCESS)
+    {
+      polarity = current_polarity;
+      ROS_FATAL("setPolarity() failed: %d", err);
+      return false; // failure
+    }
+    ROS_DEBUG("setPolarity(): %s", triggerPolarityName(polarity).c_str());
+  }
+  else
+  {
+    ROS_FATAL("Polarity is not supported");
+    return false; // failure
+  }
+
+  return true; // success
+}
+
+/** Get external trigger power state.
+ *
+ *  @param camera points to DC1394 camera struct.
+ *  @return DC1394_ON for external trigger; DC1394_OFF for internal trigger.
+ */
+dc1394switch_t Trigger::getExternalTriggerPowerState(dc1394camera_t *camera)
+{
+  dc1394switch_t state;
+
+  dc1394error_t err = dc1394_external_trigger_get_power(camera, &state);
+  if (err != DC1394_SUCCESS)
+  {
+    ROS_FATAL("getExternalTriggerPowerState() failed: %d", err);
+    return (dc1394switch_t)-1; // failure
+  }
+  externalTriggerPowerState_ = state;
+  return state;
+}
+
+/** Set external trigger power state.
+ *  @param camera points to DC1394 camera struct
+ *  @param[in,out] state Config parameter for this option,
+ *                 updated if the camera does not support the
+ *                 requested value
+ *  @return true if set successfully, false if not.
+ */
+bool Trigger::setExternalTriggerPowerState(dc1394camera_t *camera, dc1394switch_t &state)
+{
+  dc1394switch_t current_state = getExternalTriggerPowerState(camera);
+
+  // if config not changed, then do nothing
+  if(current_state == state) return true;
+
+  dc1394error_t err = dc1394_external_trigger_set_power(camera, state);
+  if (err != DC1394_SUCCESS)
+  {
+    state = current_state;
+    ROS_FATAL("setExternalTriggerPowerState() failed: %d", err);
+    return false; // failure
+  }
+  externalTriggerPowerState_ = state;
+  ROS_DEBUG("setExternalTriggerPowerState(): %s", (state == DC1394_ON ? "ON" : "OFF"));
+  return true; // success
+}
+
+/** Get software trigger power state.
+ *
+ *  @param camera points to DC1394 camera struct.
+ *  @return DC1394_ON if software trigger is on; DC1394_OFF if not.
+ */
+dc1394switch_t Trigger::getSoftwareTriggerPowerState(dc1394camera_t *camera)
+{
+  dc1394switch_t state;
+
+  dc1394error_t err = dc1394_software_trigger_get_power(camera, &state);
+  if (err != DC1394_SUCCESS)
+  {
+    ROS_FATAL("getSoftwareTriggerPowerState() failed: %d", err);
+    return (dc1394switch_t)-1; // failure
+  }
+  return state;
+}
+
+/** Set software trigger power state.
+ *  @param camera points to DC1394 camera struct
+ *  @param[in,out] state Config parameter for this option,
+ *                 updated if the camera does not support the
+ *                 requested value
+ *  @return true if set successfully, false if not.
+ */
+bool Trigger::setSoftwareTriggerPowerState(dc1394camera_t *camera, dc1394switch_t &state)
+{
+  dc1394switch_t current_state = getSoftwareTriggerPowerState(camera);
+
+  // if config not changed, then do nothing
+  if(current_state == state) return true;
+
+  dc1394error_t err = dc1394_software_trigger_set_power(camera, state);
+  if (err != DC1394_SUCCESS)
+  {
+    state = current_state;
+    ROS_FATAL("setSoftwareTriggerPowerState() failed: %d", err);
+    return false; // failure
+  }
+  ROS_DEBUG("setSoftwareTriggerPowerState(): %s", (state == DC1394_ON ? "ON" : "OFF"));
+  return true; // success
+}
+
+/** Get current trigger mode.
+ *
+ *  @param camera points to DC1394 camera struct.
+ *  @return corresponding dc1394trigger_mode_t enum value selected,
+ *                 if successful; DC1394_TRIGGER_MODE_NUM if not.
+ */
+dc1394trigger_mode_t Trigger::getMode(dc1394camera_t *camera)
+{
+  dc1394trigger_mode_t mode;
+
+  dc1394error_t err = dc1394_external_trigger_get_mode(camera, &mode);
+  if (err != DC1394_SUCCESS)
+  {
+    ROS_FATAL("getTriggerMode() failed: %d", err);
+    return (dc1394trigger_mode_t) DC1394_TRIGGER_MODE_NUM; // failure
+  }
+
+  return mode;
+}
+
+/** Set external trigger mode.
+ *  @param camera points to DC1394 camera struct
+ *  @param[in,out] mode Config parameter for this option,
+ *                 updated if the camera does not support the
+ *                 requested value
+ *  @return true if set successfully, false if not.
+ */
+bool Trigger::setMode(dc1394camera_t *camera, dc1394trigger_mode_t &mode)
+{
+  dc1394trigger_mode_t current_mode = getMode(camera);
+
+  // if config not changed, then do nothing
+  if(current_mode == mode) return true;
+
+  dc1394error_t err = dc1394_external_trigger_set_mode(camera, mode);
+  if (err != DC1394_SUCCESS)
+  {
+    mode = current_mode;
+    ROS_FATAL("setTriggerMode() failed: %d", err);
+    return false; // failure
+  }
+  ROS_DEBUG("setMode(): %s", triggerModeName(mode).c_str());
+  return true; // success
+}
+
+/** Get current trigger source.
+ *
+ *  @param camera points to DC1394 camera struct.
+ *  @return corresponding dc1394trigger_source_t enum value selected,
+ *                 if successful; DC1394_TRIGGER_SOURCE_NUM if not.
+ */
+dc1394trigger_source_t Trigger::getSource(dc1394camera_t *camera)
+{
+  dc1394trigger_source_t source;
+
+  dc1394error_t err = dc1394_external_trigger_get_source(camera, &source);
+  if (err != DC1394_SUCCESS)
+  {
+    ROS_FATAL("getTriggerSource() failed: %d", err);
+    return (dc1394trigger_source_t) DC1394_TRIGGER_SOURCE_NUM; // failure
+  }
+
+  return source;
+}
+
+/** Set external trigger source.
+ *  @param camera points to DC1394 camera struct
+ *  @param[in,out] source Config parameter for this option,
+ *                 updated if the camera does not support the
+ *                 requested value
+ *  @return true if set successfully, false if not.
+ */
+bool Trigger::setSource(dc1394camera_t *camera, dc1394trigger_source_t &source)
+{
+  dc1394trigger_source_t current_source = getSource(camera);
+
+  // if config not changed, then do nothing
+  if(current_source == source) return true;
+
+  dc1394error_t err = dc1394_external_trigger_set_source(camera, source);
+
+  if (err != DC1394_SUCCESS)
+  {
+    source = current_source;
+    ROS_FATAL("setTriggerSource() failed: %d", err);
+    return false; // failure
+  }
+  ROS_DEBUG("setSource(): %s", triggerSourceName(source).c_str());
+
+  return true; // success
+}
+
+/** reconfigures triggering parameters according to config values
+ *
+ *  @param newconfig [in,out] configuration parameters, updated
+ *         to conform with device restrictions.
+ *  @return true if successful; false if not
+ */
+bool Trigger::reconfigure(Config *newconfig)
+{
+  bool is_ok = true;
+
+  //////////////////////////////////////////////////////////////
+  // set triggering modes
+  //////////////////////////////////////////////////////////////
+  dc1394switch_t on_off = (dc1394switch_t) newconfig->external_trigger;
+  if (!Trigger::setExternalTriggerPowerState(camera_, on_off))
+  {
+    newconfig->external_trigger = on_off;
+    ROS_ERROR("Failed to set external trigger power");
+    is_ok = false;
+  }
+
+  on_off = (dc1394switch_t) newconfig->software_trigger;
+  if (!Trigger::setSoftwareTriggerPowerState(camera_, on_off))
+  {
+    newconfig->software_trigger = on_off;
+    ROS_ERROR("Failed to set software trigger power");
+    is_ok = false;
+  }
+
+  if (findTriggerMode(newconfig->trigger_mode))
+  {
+    if (!Trigger::setMode(camera_, triggerMode_))
+    {
+      // Possible if driver compiled against different version of libdc1394
+      ROS_ASSERT(triggerMode_ <= DC1394_TRIGGER_MODE_MAX);
+      newconfig->trigger_mode = Trigger::trigger_mode_names_[triggerMode_ - DC1394_TRIGGER_MODE_MIN];
+      ROS_ERROR("Failed to set trigger mode");
+      is_ok = false;
+    }
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Unknown trigger mode: " << newconfig->trigger_mode);
+    is_ok = false;
+  }
+
+  if (triggerSources_.num != 0)
+  {
+    if (findTriggerSource(newconfig->trigger_source) && checkTriggerSource(triggerSource_))
+    {
+      if (!Trigger::setSource(camera_, triggerSource_))
+      {
+        // Possible if driver compiled against different version of libdc1394
+        ROS_ASSERT(triggerSource_ <= DC1394_TRIGGER_SOURCE_MAX);
+        newconfig->trigger_source = Trigger::trigger_source_names_[triggerSource_ - DC1394_TRIGGER_SOURCE_MIN];
+        ROS_ERROR("Failed to set trigger source");
+        is_ok = false;
+      }
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Unknown trigger source: " << newconfig->trigger_source);
+      is_ok = false;
+    }
+  }
+  else
+  {
+    ROS_DEBUG("No triggering sources available");
+  }
+
+  if (findTriggerPolarity(newconfig->trigger_polarity))
+  {
+    if (!Trigger::setPolarity(camera_, triggerPolarity_))
+    {
+      // Possible if driver compiled against different version of libdc1394
+      ROS_ASSERT(triggerPolarity_ <= DC1394_TRIGGER_ACTIVE_MAX);
+      newconfig->trigger_polarity = Trigger::trigger_polarity_names_[triggerPolarity_ - DC1394_TRIGGER_ACTIVE_MIN];
+      ROS_ERROR("Failed to set trigger polarity");
+      is_ok = false;
+    }
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Unknown trigger polarity: " << newconfig->trigger_polarity);
+    is_ok = false;
+  }
+
+  return is_ok;
+}
+
+/** enumerates trigger sources and configures triggering parameters
+ *  according to config values
+ *
+ *  @param newconfig [in,out] configuration parameters, updated
+ *         to conform with device restrictions.
+ *  @return true if successful; false if not
+ */
+bool Trigger::initialize(Config *newconfig)
+{
+  ROS_INFO("[%016lx] has trigger support", camera_->guid);
+
+  // Enumerate trigger sources
+  if (!Trigger::enumSources(camera_, triggerSources_))
+  {
+    ROS_ERROR("Failed to enumerate trigger sources");
+    return false;
+  }
+
+  // Update externalTriggerPowerState_ variable with current value
+  Trigger::getExternalTriggerPowerState(camera_);
+
+  // configure trigger features
+  return reconfigure(newconfig);
+}

--- a/src/nodes/trigger.h
+++ b/src/nodes/trigger.h
@@ -1,0 +1,154 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2013 Boris Gromov, BioRobotics Lab at Korea Tech
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the author nor other contributors may be
+*     used to endorse or promote products derived from this software
+*     without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef _TRIGGER_H_
+#define _TRIGGER_H_
+
+#include <dc1394/dc1394.h>
+
+#include "camera1394stereo/Camera1394StereoConfig.h"
+typedef camera1394stereo::Camera1394StereoConfig Config;
+
+/** @file
+
+    @brief libdc1394 triggering modes interface
+
+    Functions to get or set libdc1394 triggering modes corresponding to various
+    Config parameters, limiting configured values to those actually
+    supported by the device.
+
+    @author Boris Gromov
+
+*/
+
+class Trigger
+{
+private:
+  /// driver parameter names, corresponding to DC1394 trigger modes
+  static const std::string trigger_mode_names_[DC1394_TRIGGER_MODE_NUM];
+  /// driver parameter names, corresponding to DC1394 trigger sources
+  static const std::string trigger_source_names_[DC1394_TRIGGER_SOURCE_NUM];
+  /// driver parameter names, corresponding to DC1394 trigger sources
+  static const std::string trigger_polarity_names_[DC1394_TRIGGER_ACTIVE_NUM];
+
+  dc1394camera_t *camera_;
+
+  dc1394trigger_mode_t triggerMode_;
+  dc1394trigger_source_t triggerSource_;
+  dc1394trigger_sources_t triggerSources_;
+  dc1394trigger_polarity_t triggerPolarity_;
+
+  dc1394switch_t externalTriggerPowerState_;
+
+  bool findTriggerMode(std::string str);
+  bool findTriggerSource(std::string str);
+  bool findTriggerPolarity(std::string str);
+  bool checkTriggerSource(dc1394trigger_source_t source);
+
+public:
+  /** Constructor
+   *
+   *  @param camera address of DC1394 camera structure.
+   */
+  Trigger(dc1394camera_t *camera):
+    camera_(camera), triggerSources_((dc1394trigger_sources_t){0}), externalTriggerPowerState_(DC1394_OFF)
+  {};
+
+  /** Return driver parameter name of DC1394 trigger_mode.
+   *
+   *  @param mode DC1394 trigger mode number
+   *  @return corresponding parameter name ("" if not a valid mode)
+   */
+  inline const std::string triggerModeName(dc1394trigger_mode_t mode)
+  {
+    if (mode >= DC1394_TRIGGER_MODE_MIN && mode <= DC1394_TRIGGER_MODE_MAX)
+      return trigger_mode_names_[mode - DC1394_TRIGGER_MODE_MIN];
+    else
+      return "";
+  }
+
+  /** Return driver parameter name of DC1394 trigger_source.
+   *
+   *  @param mode DC1394 trigger source number
+   *  @return corresponding parameter name ("" if not a valid mode)
+   */
+  inline const std::string triggerSourceName(dc1394trigger_source_t source)
+  {
+    if (source >= DC1394_TRIGGER_SOURCE_MIN && source <= DC1394_TRIGGER_SOURCE_MAX)
+      return trigger_source_names_[source - DC1394_TRIGGER_SOURCE_MIN];
+    else
+      return "";
+  }
+
+  /** Return driver parameter name of DC1394 trigger_polarity.
+   *
+   *  @param mode DC1394 trigger polarity
+   *  @return corresponding parameter name ("" if not a valid mode)
+   */
+  inline const std::string triggerPolarityName(dc1394trigger_polarity_t polarity)
+  {
+    if (polarity >= DC1394_TRIGGER_ACTIVE_MIN && polarity <= DC1394_TRIGGER_ACTIVE_MAX)
+      return trigger_polarity_names_[polarity - DC1394_TRIGGER_ACTIVE_MIN];
+    else
+      return "";
+  }
+
+  /** Checks whether external trigger power is ON or OFF.
+   *  This method uses cached value, which is updated every
+   *  time the settings are changed by user
+   *
+   *  @return true if external trigger power is ON; false if not
+   */
+  inline bool isPowered()
+  {
+    return (externalTriggerPowerState_ == DC1394_ON ? true : false);
+  }
+
+  bool enumSources(dc1394camera_t *camera, dc1394trigger_sources_t &sources);
+  dc1394trigger_polarity_t getPolarity(dc1394camera_t *camera);
+  bool setPolarity(dc1394camera_t *camera, dc1394trigger_polarity_t &polarity);
+  dc1394switch_t getExternalTriggerPowerState(dc1394camera_t *camera);
+  bool setExternalTriggerPowerState(dc1394camera_t *camera, dc1394switch_t &state);
+  dc1394switch_t getSoftwareTriggerPowerState(dc1394camera_t *camera);
+  bool setSoftwareTriggerPowerState(dc1394camera_t *camera, dc1394switch_t &state);
+  dc1394trigger_mode_t getMode(dc1394camera_t *camera);
+  bool setMode(dc1394camera_t *camera, dc1394trigger_mode_t &mode);
+  dc1394trigger_source_t getSource(dc1394camera_t *camera);
+  bool setSource(dc1394camera_t *camera, dc1394trigger_source_t &source);
+
+  bool reconfigure(Config *newconfig);
+  bool initialize(Config *newconfig);
+};
+
+#endif // _TRIGGER_H_


### PR DESCRIPTION
Incorporated recent additions to camera1394, tested on a hardware trigger for pgr bumblebee camera with an external hw sync signal, using the external_trigger param. Have not tested software trigger.
