### PR TITLE
Missing install rule for camera1394stereo_nodelet.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,5 +84,6 @@ install(FILES
   launch/nodelet_manager.launch
   launch/nodelet_standalone.launch
   launch/nodelet_pipeline.launch
+  camera1394stereo_nodelet.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
Running the Openni driver for the Kinect/Xtion camera, this error appears cause the xml file will not be installed:
[ERROR] [1462205768.074496376]: Skipping XML Document "/opt/ros/indigo/share/camera1394stereo/camera1394stereo_nodelet.xml" which had no Root Element.  This likely means the XML is malformed or missing.
