### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/nodes/nodelet.cpp
+++ b/src/nodes/nodelet.cpp
@@ -106,8 +106,7 @@ void Camera1394StereoNodelet::devicePoll()
     }
 }
 
-// Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
+// Register this plugin with pluginlib.  Names must match camera1394stereo_nodelet.xml.
 //
-// parameters are: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(camera1394stereo, driver,
-                        Camera1394StereoNodelet, nodelet::Nodelet);
+// parameters are: class type, base class type
+PLUGINLIB_EXPORT_CLASS(Camera1394StereoNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions